### PR TITLE
Change fast walking label colors from red to orange

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,8 +150,8 @@
                 </div>
                 <div class="mt-4 space-y-2">
                     <div class="flex items-center gap-2">
-                        <div class="w-4 h-4 bg-red-500 rounded"></div>
-                        <span class="text-sm text-red-600 font-medium">速歩き区間</span>
+                        <div class="w-4 h-4 bg-orange-500 rounded"></div>
+                        <span class="text-sm text-orange-600 font-medium">速歩き区間</span>
                     </div>
                     <div class="flex items-center gap-2">
                         <div class="w-4 h-4 bg-blue-500 rounded"></div>

--- a/js/view.js
+++ b/js/view.js
@@ -18,8 +18,8 @@ export class WalkingView {
         
         if (phase === 'fast') {
             phaseDisplay.textContent = '速歩き';
-            phaseDisplay.className = 'text-lg px-4 py-2 rounded-full text-white bg-red-500 inline-block';
-            timer.className = 'bg-red-50 border-2 border-red-200 rounded-lg p-6 shadow-sm';
+            phaseDisplay.className = 'text-lg px-4 py-2 rounded-full text-white bg-orange-500 inline-block';
+            timer.className = 'bg-orange-50 border-2 border-orange-200 rounded-lg p-6 shadow-sm';
         } else if (phase === 'slow') {
             phaseDisplay.textContent = 'ゆっくり歩き';
             phaseDisplay.className = 'text-lg px-4 py-2 rounded-full text-white bg-blue-500 inline-block';
@@ -255,7 +255,7 @@ export class WalkingView {
                 second: '2-digit'
             });
             
-            const phaseColor = location.phase === 'fast' ? 'text-red-600' : 'text-blue-600';
+            const phaseColor = location.phase === 'fast' ? 'text-orange-600' : 'text-blue-600';
             const phaseName = location.phase === 'fast' ? '速歩き' : 'ゆっくり歩き';
             
             row.innerHTML = `

--- a/tests/location-data.test.js
+++ b/tests/location-data.test.js
@@ -124,7 +124,7 @@ describe('Location Data Management', () => {
                     second: '2-digit'
                 });
                 
-                const phaseColor = location.phase === 'fast' ? 'text-red-600' : 'text-blue-600';
+                const phaseColor = location.phase === 'fast' ? 'text-orange-600' : 'text-blue-600';
                 const phaseName = location.phase === 'fast' ? '速歩き' : 'ゆっくり歩き';
                 
                 row.innerHTML = `


### PR DESCRIPTION
Fixes ##4

Changed the color of fast walking (速歩き) labels from red to orange as requested.

**Changes include:**
- Map legend colors for 速歩き区間
- Phase display and timer background colors
- Location data table text colors
- Updated test files to match new color scheme

Generated with [Claude Code](https://claude.ai/code)