### PR TITLE
Fix distance display inconsistency between session lists and details

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -316,9 +316,17 @@ export class WalkingController {
                 return;
             }
 
-            sessions.forEach(session => {
+            // Recalculate distance for each session from location data
+            for (const session of sessions) {
+                const locations = await this.model.getLocationsBySessionId(session.id);
+                if (locations && locations.length > 0) {
+                    const calculatedDistance = this.calculateTotalDistance(locations);
+                    session.calculatedDistance = calculatedDistance;
+                    // Update the session.distance field to ensure consistency
+                    session.distance = calculatedDistance;
+                }
                 sessionList.appendChild(this.view.addSessionToDOM(session));
-            });
+            }
 
             // Show "more" button only if there are more than 3 sessions total
             if (allSessionsCount > 3) {
@@ -342,9 +350,17 @@ export class WalkingController {
                 return;
             }
 
-            sessions.forEach(session => {
+            // Recalculate distance for each session from location data
+            for (const session of sessions) {
+                const locations = await this.model.getLocationsBySessionId(session.id);
+                if (locations && locations.length > 0) {
+                    const calculatedDistance = this.calculateTotalDistance(locations);
+                    session.calculatedDistance = calculatedDistance;
+                    // Update the session.distance field to ensure consistency
+                    session.distance = calculatedDistance;
+                }
                 allSessionsList.appendChild(this.view.addSessionToAllSessionsDOM(session));
-            });
+            }
 
             const totalPages = Math.ceil(totalCount / 10);
             this.view.updatePaginationControls(page, totalPages, totalCount);


### PR DESCRIPTION
This PR fixes the issue where distance is shown in session details but not displayed in the session list.

## Changes
- Modified both `loadSessions()` and `loadAllSessions()` methods in `js/controller.js`
- Added distance recalculation from location data for session list items
- Ensures consistent distance display across all session views

## Issue Analysis
The problem was that session details view recalculated distance from location data, but session lists only used the stored `session.distance` field. This fix applies the same distance calculation logic to all views.

Resolves #10

Generated with [Claude Code](https://claude.ai/code)