### PR TITLE
Fix app icon and title alignment issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,20 +27,17 @@
         <!-- Main View -->
         <div id="mainView">
             <!-- Header -->
-            <div class="text-center mb-8">
-                <div class="flex justify-between items-start mb-4">
-                    <div></div>
-                    <div>
-                        <img src="icon.png" alt="Japanese Walking" class="w-20 h-20 mx-auto mb-4">
-                        <h1 class="text-3xl font-bold text-gray-800">Japanese Walking</h1>
-                        <p class="text-gray-600 mt-2">インターバル速歩で健康習慣を身につけよう</p>
-                    </div>
-                    <button id="dataManagementBtn" class="p-2 text-gray-500 hover:text-gray-700" title="データ管理">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
-                        </svg>
-                    </button>
+            <div class="text-center mb-8 relative">
+                <div class="mb-4">
+                    <img src="icon.png" alt="Japanese Walking" class="w-20 h-20 mx-auto mb-4">
+                    <h1 class="text-3xl font-bold text-gray-800">Japanese Walking</h1>
+                    <p class="text-gray-600 mt-2">インターバル速歩で健康習慣を身につけよう</p>
                 </div>
+                <button id="dataManagementBtn" class="absolute top-0 right-0 p-2 text-gray-500 hover:text-gray-700" title="データ管理">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                    </svg>
+                </button>
             </div>
             
             <!-- Start Button -->


### PR DESCRIPTION
Fixes #16

The app icon and title were slightly shifted to the left of center due to the data management icon in the top right.

## Changes
- Replaced flexbox `justify-between` layout with absolute positioning for the data management button
- App icon and title are now truly centered using `text-center` on the parent container
- Data management button is positioned absolutely in the top-right corner

Generated with [Claude Code](https://claude.ai/code)